### PR TITLE
Fix bug

### DIFF
--- a/src/main/java/com/taobao/rigel/rap/common/listener/SessionListener.java
+++ b/src/main/java/com/taobao/rigel/rap/common/listener/SessionListener.java
@@ -39,7 +39,7 @@ public class SessionListener implements HttpSessionListener {
         // unlock project
         Object userIdObj = session.getAttribute(ContextManager.KEY_USER_ID);
         if (userIdObj != null) {
-            long userId = (Long) userIdObj;
+            int userId = ((Integer) userIdObj).intValue();
             Object projectLockListObj = context.getAttribute(ContextManager.KEY_PROJECT_LOCK_LIST);
             if (projectLockListObj != null) {
                 Map projectLockList = (Map) projectLockListObj;


### PR DESCRIPTION
27-Aug-2017 13:09:58.584 SEVERE [ContainerBackgroundProcessor[StandardEngine[Catalina]]] org.apache.catalina.session.StandardSession.expire Session event listener threw exception
 java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.Long
        at com.taobao.rigel.rap.common.listener.SessionListener.sessionDestroyed(SessionListener.java:42)